### PR TITLE
Introduce a hierarchy to the TOC using subpages

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -2,28 +2,22 @@
 
 * [Introduction](README.md)
 
-## Consume Data
-
 * [Consume Data](consumers/consume-data.md)
-* [Best Practices](consumers/best-practices.md)
-
-## Publish Data
+  * [Best Practices](consumers/best-practices.md)
 
 * [Publish Data](publishers/publish-data.md)
-* [Understanding Publishing Slots](publishers/understanding-publishing-slots.md)
-* [pyth-client Websocket API](publishers/pyth-client-websocket-api.md)
-* [Confidence Interval and Crypto Exchange Fees](publishers/confidence-interval-and-crypto-exchange-fees.md)
-
-## How Pyth Works
+  * [Understanding Publishing Slots](publishers/understanding-publishing-slots.md)
+  * [pyth-client Websocket API](publishers/pyth-client-websocket-api.md)
+  * [Confidence Interval and Crypto Exchange Fees](publishers/confidence-interval-and-crypto-exchange-fees.md)
 
 * [How Pyth Works](how-pyth-works/how-pyth-works.md)
-* [Design Overview](how-pyth-works/design-overview.md)
-* [Account Structure](how-pyth-works/account-structure.md)
-* [Product Metadata](how-pyth-works/product-metadata.md)
-* [Price Aggregation](how-pyth-works/price-aggregation.md)
-* [EMA Price Aggregation](how-pyth-works/ema-price-aggregation.md)
-* [Accounts](https://pyth.network/developers/accounts/)
-* [Network Participants](how-pyth-works/network-participants.md)
-* [Network Interactions](how-pyth-works/network-interactions.md)
-* [Claims Process](how-pyth-works/claims-process.md)
-* [Participant Incentives](how-pyth-works/participant-incentives.md)
+  * [Design Overview](how-pyth-works/design-overview.md)
+  * [Account Structure](how-pyth-works/account-structure.md)
+  * [Product Metadata](how-pyth-works/product-metadata.md)
+  * [Price Aggregation](how-pyth-works/price-aggregation.md)
+  * [EMA Price Aggregation](how-pyth-works/ema-price-aggregation.md)
+  * [Accounts](https://pyth.network/developers/accounts/)
+  * [Network Participants](how-pyth-works/network-participants.md)
+  * [Network Interactions](how-pyth-works/network-interactions.md)
+  * [Claims Process](how-pyth-works/claims-process.md)
+  * [Participant Incentives](how-pyth-works/participant-incentives.md)


### PR DESCRIPTION
This means pages will only be visible in the sidebar when users are in the relevant section, so users only see pages that are relevant to their use case.