### PR TITLE
Update Publish Data entrypoint with latest instructions from repo

### DIFF
--- a/publishers/publish-data.md
+++ b/publishers/publish-data.md
@@ -1,21 +1,21 @@
-# Publish Data
+# Getting started with publishing via pyth-client
 
-> This page makes references to the Solana CLI. For more information, see [https://docs.solana.com/cli](https://docs.solana.com/cli)
+The pyth-client repo consists of two command-line administration tools (pyth & pyth_admin) and a json/websocket-based server (pythd).
 
-To get started as a publisher, first pull the [pyth-client](https://github.com/pyth-network/pyth-client) repo. This repo consists of a C++ library (libpc.a), two command-line administration tools (pyth & pyth\_admin), a json/websocket-based server (pythd) and a gateway/proxy server for price publishing (pyth\_tx).
+You can integrate with the pythd server via json/websockets. See `pctest/test_publish.py` for an example.
 
-You can integrate with libpc directly in your application. See `pctest/test_publish.cpp` for an example. Or, you can integrate with the pythd server via json/websockets. See `pctest/test_publish.py` for an example.
+Before doing this you need to setup a *key-store* directory. A key-store is a collection of cryptographic keys for interacting with the solana block-chain. This can be done via the pyth command-line tool.  First, build the project by following the instructions in the README.md file and cd to the build directory, then run the following:
 
-Before doing this you need to setup a _key-store_ directory. A key-store is a collection of cryptographic keys for interracting with the solana block-chain. This can be done via the pyth command-line tool. First, build the project by following the instructions in the README.md file and cd to the build directory, then run the following:
 
 ```
 KDIR=$HOME/.pythd
 ./pyth init_key -k $KDIR
+
 ```
 
 You can replace `$KDIR` with a directory of your choice.
 
-This creates the directory (if it didnt already exist) and creates a key-pair file containing the identifier you're going to use to publish to the block-chain: `$KDIR/publish_key_pair.json`.
+This creates the directory (if it didn't already exist) and creates a key-pair file containing the identifier you're going to use to publish to the block-chain: `$KDIR/publish_key_pair.json`.
 
 Please extract the public key from this key-pair and send it to the administrator so it can be permissioned for your symbols of interest. The public key can be extracted as follows:
 
@@ -29,65 +29,44 @@ This will output the public key in base58 encoding and will look something like:
 5rYvdyWAunZgD2EC1aKo7hQbutUUnkt7bBFM6xNq2z7Z
 ```
 
-Once permissioned, you need two additional public keys in the key-store. The id of the mapping-account that contains the directory listing of the on-chain symbols and the id of the on-chain oracle program that you use to publish prices. Mapping and program accounts are maintained in two separate environments: devnet and forthcoming mainnet-beta.
+Once permissioned, you need two additional public keys in the key-store. The id of the mapping-account that contains the directory listing of the on-chain symbols and the id of the on-chain oracle program that you use to publish prices.  Mapping and program accounts are maintained in two separate environments: devnet and forthcoming mainnet-beta.
 
-Use the init\_key\_store.sh script to initialize these account keys:
+Use the init_key_store.sh script to initialize these account keys:
 
 ```
-KENV=devnet  # or testnet, prodbeta
+KENV=devnet  # or testnet, mainnet
 
 # initialize keys for solana devnet
 ../pctest/init_key_store.sh $KENV $KDIR
+
 ```
 
 This creates two files: `$KDIR/mapping_key.json` and `$KDIR/program_key.json`.
 
-Once permissioned, you can test your setup by running the test\_publish.cpp example program for publishing and subscribing to two test symbols. To test publishing on devnet you need to run:
+Once permissioned, you can test your setup by running the test_publish.py example program against pythd for publishing and subscribing to a test symbol.  To test publishing on devnet you first need to run an instance of the pythd server:
+
 
 ```
 RHOST=api.devnet.solana.com
-THOST=<your_pyth_tx_host>
-./test_publish -k $KDIR -r $RHOST -t $THOST
+./pythd -k $KDIR -r $RHOST -x
 ```
 
-The -r and -t options correspond to the locations of required solana validator and pyth\_tx server instances.
+Where RHOST is the location of the Solana validator instance.
 
-You can also publish to solana using the pythd server. Start up the server using the same key-store directory and host specification:
-
-```
-./pythd -k $KDIR -r $RHOST -t $THOST
-```
-
-Run the test\_publish.py example program on the same host to connect to the pythd server:
+Run the test_publish.py example program on the same host to connect to the pythd server:
 
 ```
 ../pctest/test_publish.py
-```
-
-## Running the pyth\_tx server
-
-The pyth-client API connects to two separate services via TCP. These include the solana validator and pyth\_tx servers. The pyth\_tx server is included in the pyth-client repository.
-
-The solana rpc interface is used for tracking slot and account updates. The pyth\_tx server is used to submit price transactions directly to solana leader nodes via UDP.
-
-pyth\_tx runs as a separate server rather than being integrated directly into the client library to avoid a publisher from having to submit UDP datagrams to hundreds of different IP address from within an organization's firewall. Instead, a pyth\_tx server can be deployed outside the firewall and a publisher clienti, running inside the firewall, can make a single TCP connection to it on a dedicated port.
-
-You can run your own pyth\_tx instance (recommended) or connect to provided server instances running against mainnet-beta.
-
-Start up the pyth\_tx server as follows:
 
 ```
-./pyth_tx -r $KHOST
-```
 
-The -r option points to the IP address of a solana validator node or rpc end-point. It can be the same or different IP address to that passed to test\_publish or pythd as long as it corresponds to the same environment.
 
 ## Running the dashboard
 
-The pythd server also exports a dashboard web page for watching the ticking pyth prices. The public key you create above does not need publish-permission to watch the ticking pyth prices. To activate the dashboard page include an additional `-w` argument to pythd pointing at the html/javscript code directory:
+The pythd server also exports a dashboard web page for watching the ticking pyth prices.  The public key you create above does not need publish-permission to watch the ticking pyth prices.  To activate the dashboard page include an additional `-w` argument to pythd pointing at the html/javscript code directory:
 
 ```
 ./pythd -k $KDIR -r $RHOST -w ../dashboard
 ```
 
-Connect to the dashboard via [http://localhost:8910](http://localhost:8910).
+Connect to the dashboard via http://localhost:8910.


### PR DESCRIPTION
This pulls in the latest changes to the "Getting Started" doc from the pyth-client repo, which should now live on the GitBook:

- Removes references to the C++ bindings.
- Removes references to `pyth_tx`.

This document could do with a lot of love, but for now we're just pulling in the changes from the repo.