### PR TITLE
Document how to find price accounts from the website

### DIFF
--- a/consumers/solana.md
+++ b/consumers/solana.md
@@ -40,7 +40,7 @@ The [Blockdaemon pyth-go](https://github.com/Blockdaemon/pyth-go) client can be 
 
 ## Price Feeds
 
-All the price feeds available on Solana are listed on the [pyth.network website](https://pyth.network/markets/). To consume a price feed, you need to look up the price feed ID for the symbol you're interested in. On Solana, this corresponds to the price account for that symbol.
+All the price feeds available on Solana are listed on the [pyth.network website](https://pyth.network/markets/). To consume a price feed, you need to look up the price feed ID for the symbol you're interested in. On Solana, this corresponds to the public key of that symbols' price account.
 
 As an example, to find the price feed ID for BTC/USD in Devnet:
 


### PR DESCRIPTION
Soon the website will list price feed IDs for each blockchain, but for now this should be documented.

We also remove the reference to the Solana account structure, as this should be considered an implementation detail.