### PR TITLE
Remove documentation for deprecated subscribe_price websocket method

### DIFF
--- a/publishers/pyth-client-websocket-api.md
+++ b/publishers/pyth-client-websocket-api.md
@@ -4,7 +4,6 @@ The pythd daemon supports a websocket interface based on the json-rpc 2.0 standa
 
 * [get\_product\_list](pyth-client-websocket-api.md#get\_product\_list)
 * [update\_price](pyth-client-websocket-api.md#update\_price)
-* [subscribe\_price](pyth-client-websocket-api.md#subscribe\_price)
 * [subscribe\_price\_sched](pyth-client-websocket-api.md#subscribe\_price\_sched)
 * [get\_product](pyth-client-websocket-api.md#get\_product)
 * [get\_all\_products](pyth-client-websocket-api.md#get\_all\_products)
@@ -109,58 +108,6 @@ A successful response looks like:
   "id" : 1
 }
 ```
-
-## subscribe\_price
-
-Subscribe to symbol price updates.
-
-The request looks like:
-
-```
-{
-  "jsonrpc": "2.0",
-  "method": "subscribe_price",
-  "params" : {
-    "account": "CrZCEEt3awgkGLnVbsv45Pp4aLhr7fZfZr3ubzrbNXaq",
-  },
-  "id" : 1
-}
-```
-
-A successful response looks like:
-
-```
-{
-  "jsonrpc": "2.0",
-  "result" : {
-    "subscription" : 1234
-  },
-  "id" : 1
-}
-```
-
-The subscription identifier in the result is used in all subsequent notifications for this subscription. An example notification (with the same subscription id) looks like:
-
-```
-{
-  "jsonrpc": "2.0",
-  "method": "notify_price",
-  "params": {
-    "result": {
-      "price" : 42002,
-      "conf" : 3,
-      "status" : "trading",
-      "valid_slot" : 32008,
-      "pub_slot" : 32009
-    },
-    "subscription" : 1234
-  }
-}
-```
-
-Results include the most recent aggregate price, confidence interval and symbol status. pythd will submit a `notify_price` message immediately upon subscription with the latest price instead of waiting for an update.
-
-Results also include two slot numbers. `valid_slot` corresponds to the slot containing the prices that were used to compute the aggregate price. `pub_slot` corresponds to the slot in which the aggregation price was published.
 
 ## subscribe\_price\_sched
 


### PR DESCRIPTION
We want to discourage new publishers from using this method. They should instead use our SDKs for consuming prices.