### PR TITLE
Update javascript docs

### DIFF
--- a/consumers/off-chain.md
+++ b/consumers/off-chain.md
@@ -1,10 +1,17 @@
 # Off-Chain Applications
 
-We provide SDKs in various programming languages that allow you to read the values of Pyth price feeds in off-chain applications, such as web frontends:
+We provide SDKs in various programming languages that allow you to read the values of Pyth price feeds in off-chain applications, such as web frontends.
 
 {% tabs %}
 {% tab title="JavaScript" %}
-The [@pythnetwork/client](https://www.npmjs.com/package/@pythnetwork/client) npm package can be used to consume Pyth prices inside your off-chain JavaScript programs. An example can be found [here](https://github.com/pyth-network/pyth-client-js#example-usage).
+There are different javascript SDKs for different purposes.
+
+If you are developing an application that runs on any blockchain except Solana, then the [javascript SDK for that blockchain](https://github.com/pyth-network/pyth-js) supports querying and streaming live Pyth prices.
+These SDKs also support generating [on-demand price updates](on-demand.md) for your target blockchain.
+An example for querying and streaming prices using these SDKs is shown [here](https://github.com/pyth-network/pyth-js/tree/main/pyth-evm-js#off-chain-prices).
+
+If you are developing an application for Solana, or without any blockchain whatsoever, then the [@pythnetwork/client](https://www.npmjs.com/package/@pythnetwork/client) npm package can be used to consume Pyth prices inside off-chain JavaScript programs.
+An example can be found [here](https://github.com/pyth-network/pyth-client-js#example-usage).
 {% endtab %}
 
 {% tab title="Rust" %}

--- a/consumers/off-chain.md
+++ b/consumers/off-chain.md
@@ -1,6 +1,6 @@
 # Off-Chain Applications
 
-We provide SDKs in various programming languages that allow you to read the values of Pyth price feeds in off-chain applications, such as web frontends.
+We provide SDKs in various programming languages that allow you to read the values of Pyth price feeds in off-chain applications, such as web frontends:
 
 {% tabs %}
 {% tab title="JavaScript" %}


### PR DESCRIPTION
Someone tried to use pyth-client-js for their aptos app. Add some text to gitbook pointing them to the right way to stream prices for crosschain.