### PR TITLE
Price service docs starting point

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -5,6 +5,7 @@
 * [Consume Price Feeds](consumers/consume-data.md)
   * [On-Demand Updates](consumers/on-demand.md)
   * [Using Price Feeds](consumers/best-practices.md)
+  * [Price Service](consumers/price-service.md)
   * [Pyth on Solana](consumers/solana.md)
   * [Pyth on EVM](consumers/evm.md)
   * [Pyth on Aptos](consumers/aptos.md)  

--- a/consumers/on-demand.md
+++ b/consumers/on-demand.md
@@ -39,6 +39,7 @@ The on-demand model has several benefits over the push model:
 Developers integrating with Pyth Network should build their application to submit the necessary price updates on their users' behalf.
 For example, if you need the BTC/USD price on-chain, then your frontend should submit the BTC/USD Pyth price update in every transaction that needs it.
 The [Pyth Network SDKs](consume-data.md) cover both parts of this integration -- frontend and contract -- and are designed to simplify this process.
+Developers should also host an instance of the [price service](price-service.md), which is a convenient wrapper around the Wormhole Network that the frontend SDKs use to fetch on-demand updates.
 
 ## Fees
 

--- a/consumers/price-service.md
+++ b/consumers/price-service.md
@@ -1,14 +1,19 @@
-# Price Service API
+# Price Service
 
-Pyth Network
+The [price service](https://github.com/pyth-network/pyth-crosschain/tree/main/third_party/pyth/price-service) is a webservice that listens to the Wormhole Network for Pyth price updates and serves them via a convenient web API.
+The service allows users to easily query for recent price updates via a REST API, or subscribe to a websocket for streaming updates.
+The Pyth Network Javascript SDKs connect to an instance of the price service in order to fetch on-demand price updates.
 
 ## Public Endpoints
 
-The Pyth Data Association operates two public endpoints for the price service, one for mainnet and testnet respectively.
-although it is strongly recommended to host your own instance.
-
+The Pyth Data Association operates two public endpoints for the price service, for mainnet and testnet respectively.
+These endpoints can be used to test integrations with Pyth Network:
 
 | network | url                             |
 | ------- | ------------------------------- |
 | mainnet | https://xc-mainnet.pyth.network |
 | testnet | https://xc-testnet.pyth.network |
+
+For production deployments, developers integrating with Pyth Network are **strongly encouraged** to host their own instance of the price service for maximum resilience and decentralization.
+By running an independent instance of this service, developers tap directly into Wormhole's peer-to-peer network to stream Pyth price updates.
+This peer-to-peer network has built-in redundancy and is therefore inherently more reliable than a centralized service operated by the PDA.

--- a/consumers/price-service.md
+++ b/consumers/price-service.md
@@ -1,0 +1,14 @@
+# Price Service API
+
+Pyth Network
+
+## Public Endpoints
+
+The Pyth Data Association operates two public endpoints for the price service, one for mainnet and testnet respectively.
+although it is strongly recommended to host your own instance.
+
+
+| network | url                             |
+| ------- | ------------------------------- |
+| mainnet | https://xc-mainnet.pyth.network |
+| testnet | https://xc-testnet.pyth.network |


### PR DESCRIPTION
Wrote some basic material about the price service here. I think we should add a list of API methods and also clean up the price service readme a bit so that it's trivial for someone to start up their own instance.