### PR TITLE
Add a security page to gitbook

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -30,6 +30,8 @@
   * [Price Aggregation](how-pyth-works/price-aggregation.md)
   * [EMA Price Aggregation](how-pyth-works/ema-price-aggregation.md)
 
+* [Security](security/security.md)
+
 * [Whitepaper](whitepaper/whitepaper.md)
   * [Network Participants](whitepaper/network-participants.md)
   * [Network Interactions](whitepaper/network-interactions.md)

--- a/security/security.md
+++ b/security/security.md
@@ -1,0 +1,7 @@
+# Security
+
+The Pyth software has undergone a number of audits from different firms.
+All of the audit reports are available in the [audits github repository](https://github.com/pyth-network/audit-reports).
+
+Pyth Network also offers a [bug bounty program](https://pyth.network/bounty) for reports of issues with the deployed code.
+Please visit the linked page for terms and conditions.


### PR DESCRIPTION
The content is minimal at the moment. However, I think it's good to put the links to the audits & bug bounty somewhere in gitbook, and this seems like the best approach.