### PR TITLE
Point links to pyth-crosschain

### DIFF
--- a/pythnet-price-feeds/aptos.md
+++ b/pythnet-price-feeds/aptos.md
@@ -8,11 +8,11 @@ Aptos contracts can update and fetch the Pyth prices using the Pyth Aptos Contra
 
 ## Updating Price Feeds
 
-The mechanism by which price feeds are updated on Aptos is explained [here](./pythnet-price-feeds.md). The [pyth-aptos-js](https://github.com/pyth-network/pyth-js/tree/main/pyth-aptos-js) package can be used to fetch price feed update data which can be passed to the `pyth::update_price` on-chain function.
+The mechanism by which price feeds are updated on Aptos is explained [here](./pythnet-price-feeds.md). The [pyth-aptos-js](https://github.com/pyth-network/pyth-crosschain/tree/main/target_chains/aptos/sdk/js) package can be used to fetch price feed update data which can be passed to the `pyth::update_price` on-chain function.
 
 ## Examples
 - [Minimal on-chain contract](https://github.com/pyth-network/pyth-crosschain/blob/main/target_chains/aptos/examples/fetch_btc_price/sources/example.move) which updates and returns the Pyth BTC/USD price.
-- [Full-stack React app and on-chain contract](https://github.com/pyth-network/pyth-crosschain/tree/main/target_chains/aptos/examples/mint_nft) which uses the [pyth-aptos-js](https://github.com/pyth-network/pyth-js/tree/main/pyth-aptos-js) package to update the price used by the contract.
+- [Full-stack React app and on-chain contract](https://github.com/pyth-network/pyth-crosschain/tree/main/target_chains/aptos/examples/mint_nft) which uses the [pyth-aptos-js](https://github.com/pyth-network/pyth-crosschain/tree/main/target_chains/aptos/sdk/js) package to update the price used by the contract.
 
 ## Networks 
 

--- a/pythnet-price-feeds/cosmwasm.md
+++ b/pythnet-price-feeds/cosmwasm.md
@@ -8,7 +8,7 @@ Cosmwasm contracts can update and fetch the Pyth prices using the Pyth Cosmwasm 
 
 ## Updating Price Feeds
 
-The mechanism by which price feeds are updated on Cosmwasm is explained [here](./pythnet-price-feeds.md). The [pyth-common-js](https://github.com/pyth-network/pyth-js/tree/main/pyth-common-js) can be used to fetch the latest price feed data which then can be passed to the `ExecuteMsg`, on-chain function.
+The mechanism by which price feeds are updated on Cosmwasm is explained [here](./pythnet-price-feeds.md). The [pyth-common-js](https://github.com/pyth-network/pyth-crosschain/tree/main/target_chains/cosmwasm/sdk/js) can be used to fetch the latest price feed data which then can be passed to the `ExecuteMsg`, on-chain function.
 
 ## Examples
 - [Minimal on-chain contract](https://github.com/pyth-network/pyth-crosschain/blob/main/target_chains/cosmwasm/examples/cw-contract) which queries the pyth contract. 

--- a/pythnet-price-feeds/evm.md
+++ b/pythnet-price-feeds/evm.md
@@ -4,11 +4,11 @@ description: Consume Pyth Network prices in EVM applications
 
 # Pyth on EVM
 
-On-chain EVM programs can use the [Solidity SDK](https://github.com/pyth-network/pyth-sdk-solidity) to read Pyth prices. The off-chain portion of the application can use [pyth-evm-js](https://github.com/pyth-network/pyth-js/tree/main/pyth-evm-js) to generate price update transactions. This repository's [Quickstart](https://github.com/pyth-network/pyth-js/tree/main/pyth-evm-js#quickstart) includes an example of both the on- and off-chain code necessary to integrate with Pyth.
+On-chain EVM programs can use the [Solidity SDK](https://github.com/pyth-network/pyth-sdk-solidity) to read Pyth prices. The off-chain portion of the application can use [pyth-evm-js](https://github.com/pyth-network/pyth-crosschain/tree/main/target_chains/ethereum/sdk/js) to generate price update transactions. This repository's [Quickstart](https://github.com/pyth-network/pyth-crosschain/tree/main/target_chains/ethereum/sdk/js#quickstart) includes an example of both the on- and off-chain code necessary to integrate with Pyth.
 
 ## EVM price pusher
 
-[Pyth EVM price pusher](https://github.com/pyth-network/pyth-js/tree/main/pyth-evm-price-pusher)
+[Pyth EVM price pusher](https://github.com/pyth-network/pyth-crosschain/tree/main/price_pusher)
 is a service that regularly pushes price updates to the on-chain Pyth contract.
 Protocols can run this service to push regular updates to the on-chain Pyth price based on various conditions, such as a minimum update frequency, or a price change threshold.
 This service is useful for protocols that already depend on regular push updates and want to simplify  migrating to Pyth.

--- a/pythnet-price-feeds/off-chain.md
+++ b/pythnet-price-feeds/off-chain.md
@@ -6,9 +6,10 @@ We provide SDKs in various programming languages that allow you to read the valu
 {% tab title="JavaScript" %}
 There are different javascript SDKs for different purposes.
 
-If you are developing an application that runs on any blockchain except Solana, then the [javascript SDK for that blockchain](https://github.com/pyth-network/pyth-js) supports querying and streaming live Pyth prices.
+If you are developing an application that runs on any blockchain except Solana, then the javascript SDK for that blockchain supports querying and streaming live Pyth prices.
+You can find the code for this SDK in the [pyth-crosschain](https://github.com/pyth-network/pyth-crosschain) repository, under `target_chains/<chain name>/sdk/js`.
 These SDKs also support generating [on-demand price updates](on-demand.md) for your target blockchain.
-An example for querying and streaming prices using these SDKs is shown [here](https://github.com/pyth-network/pyth-js/tree/main/pyth-evm-js#off-chain-prices).
+An example for querying and streaming prices using these SDKs is shown [here](https://github.com/pyth-network/pyth-crosschain/tree/main/target_chains/ethereum/sdk/js#off-chain-prices).
 
 If you are developing an application for Solana, or without any blockchain whatsoever, then the [@pythnetwork/client](https://www.npmjs.com/package/@pythnetwork/client) npm package can be used to consume Pyth prices inside off-chain JavaScript programs.
 An example can be found [here](https://github.com/pyth-network/pyth-client-js#example-usage).


### PR DESCRIPTION
Replace links to the pyth-js repo with links to the relevant spot in pyth-crosschain