### PR TITLE
[gitbook] broken links and pythnet addition

### DIFF
--- a/how-pyth-works/account-structure.md
+++ b/how-pyth-works/account-structure.md
@@ -6,7 +6,7 @@ The Pyth oracle program manages a number of on-chain accounts. There are three d
 2. _Price accounts_ store the current price information for a particular product. This account has fields such as the current price, a confidence interval, an exponential moving average price, an exponential moving average confidence interval and whether or not a price is currently available.
 3. _Mapping accounts_ serve as a listing of other accounts. The mapping accounts are organized into a linked list whose values are the set of product accounts. These accounts allow applications to enumerate the full list of products whose prices are available on Pyth.&#x20;
 
-The [Pyth Rust Client Library](https://github.com/pyth-network/pyth-client-rs) contains a sample application that prints the current content of all Pyth accounts. We will use the output of this application to better understand the content of these accounts.
+The [Pyth Rust Client Library](https://github.com/pyth-network/pyth-sdk-rs) contains a sample application that prints the current content of all Pyth accounts. We will use the output of this application to better understand the content of these accounts.
 
 **Product Accounts**
 

--- a/publishers/understanding-publishing-slots.md
+++ b/publishers/understanding-publishing-slots.md
@@ -1,12 +1,12 @@
 # Understanding Publishing Slots
 
-When a quoter publishes a price, the pyth-client API also forwards what it thinks is the current slot on solana. This is known as its publishing slot.
+When a quoter publishes a price, the pyth-client API also forwards what it thinks is the current slot on Solana and Pythnet. This is known as its publishing slot.
 
 The publishing slot and price is stored as the latest update for that publisher on-chain but only if the price is for a later slot than that currently stored. This is to prevent prices from being updated out-of-order and to facilitate arbitration between multiple publishers.
 
 The aggregation algorithm only combines prices from publishers that were published within 25 slots of the current on-chain slot.
 
-Not all published prices get included in the pyth contract due to unreliable transports and the way solana formulates and reaches consensus on each slot.
+Not all published prices get included in the pyth contract due to unreliable transports and the way Solana and Pythnet formulate and reach consensus on each slot.
 
 A quoter may detect if a published price is dropped by comparing the list of publishing slots it submits vs what it subsequently receives in each aggregate price callback.
 

--- a/pythnet-price-feeds/aptos.md
+++ b/pythnet-price-feeds/aptos.md
@@ -17,7 +17,7 @@ The mechanism by which price feeds are updated on Aptos is explained [here](./py
 
 ## Networks 
 
-Pyth is currently deployed on Aptos Mainnet.
+Pyth is currently deployed on Aptos Mainnet and Testnet.
 
 ## Addresses
 

--- a/pythnet-price-feeds/evm.md
+++ b/pythnet-price-feeds/evm.md
@@ -17,16 +17,14 @@ Please see the github readme for additional information on this service.
 In addition, you can find an in-depth explanation from one of our contributors, Ali:
 [How to Build with Pyth Data on EVM Chains (with Pusher): Pyth Tutorials](https://youtu.be/yhmo81JOH10)
 
-## Networks
-
-Pyth is currently available on the following EVM-based chains:
-
 ## Example - Oracle Swap 
 
 [Oracle Swap](https://github.com/pyth-network/pyth-crosschain/tree/main/target_chains/ethereum/examples/oracle_swap) is an end-to-end example application that uses Pyth Network. This application is an AMM that allows users to swap two assets at the Pyth-provided exchange rate. This application contains both the contract, and
 the frontend to interact with the contract. **Warning this example is intended only as a demonstration of Pyth price feeds and is not for production use**.
 
+## Networks
 
+Pyth is currently available on the following EVM-based chains:
 
 ### Mainnet
 

--- a/solana-price-feeds/solana.md
+++ b/solana-price-feeds/solana.md
@@ -4,19 +4,10 @@ description: Consume Pyth prices in Solana programs.
 
 # Pyth on Solana
 
-We provide two different SDKs for Solana on-chain programs to use Pyth prices:
+We provide one SDK for Solana on-chain programs to use Pyth prices:
 
-{% tabs %}
-{% tab title="Rust" %}
 The [pyth-sdk-solana crate](https://github.com/pyth-network/pyth-sdk-rs/tree/main/pyth-sdk-solana) can be used to consume Pyth prices inside Solana programs written in Rust.
-{% endtab %}
 
-{% tab title="NEON EVM" %}
-[NEON](https://neon-labs.org) is an EVM compatibility layer for Solana, allowing users to migrate their Ethereum applications to Solana with minimum effort.
-
-The [pyth-neon](https://github.com/pyth-network/pyth-neon) library is an interface to Pyth oracles for NEON applications.
-{% endtab %}
-{% endtabs %}
 
 ## Example Program
 


### PR DESCRIPTION
- fix broken link to old solana rust client
- add pythnet mentions next to solana in the publisher section
- add testnet mention for aptos
- replace networks properly for the evm chains